### PR TITLE
Flag a STRING or a PATH_QUOTE token as unterminated when it only includes the opening quote

### DIFF
--- a/lib/lexer-test.js
+++ b/lib/lexer-test.js
@@ -1338,6 +1338,10 @@ test('tokenize strings', t => {
   // we should be able to highlight things that are still being typed
   // so open-ended STRING, PATH_BRACE, and PATH_QUOTE tokens at the
   // end of output are tagged.
+  t.isTokens('="', [
+    { type: FX_PREFIX, value: '=' },
+    { type: STRING, value: '"', unterminated: true }
+  ]);
   t.isTokens('="incomple', [
     { type: FX_PREFIX, value: '=' },
     { type: STRING, value: '"incomple', unterminated: true }
@@ -1345,6 +1349,10 @@ test('tokenize strings', t => {
   t.isTokens('=[Foo', [
     { type: FX_PREFIX, value: '=' },
     { type: PATH_BRACE, value: '[Foo', unterminated: true }
+  ]);
+  t.isTokens("='", [
+    { type: FX_PREFIX, value: '=' },
+    { type: PATH_QUOTE, value: "'", unterminated: true }
   ]);
   t.isTokens("='Sheet name", [
     { type: FX_PREFIX, value: '=' },

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -75,13 +75,13 @@ export function getTokens (fx, tokenHandlers, options = {}) {
       ...(emitRanges ? { range: [ startPos, pos ] } : {})
     };
 
-    if (tokenType === STRING && !tokenValue.endsWith('"')) {
+    if (tokenType === STRING && (tokenValue === '"' || !tokenValue.endsWith('"'))) {
       token.unterminated = true;
     }
     else if (tokenType === PATH_BRACE && !tokenValue.endsWith(']')) {
       token.unterminated = true;
     }
-    else if (tokenType === PATH_QUOTE && !tokenValue.endsWith("'")) {
+    else if (tokenType === PATH_QUOTE && (tokenValue === "'" || !tokenValue.endsWith("'"))) {
       token.unterminated = true;
     }
 


### PR DESCRIPTION
Fixes the case where an incomplete formula like `="` is correctly tokenised as an `FX_PREFIX` token followed by a `STRING` token, but the `STRING` token isn't flagged as unterminated. Same for a `PATH_QUOTE` token (`='`).