### PR TITLE
Partial Row and Column Ranges

### DIFF
--- a/lib/a1-test.js
+++ b/lib/a1-test.js
@@ -70,6 +70,22 @@ test('parse A1 references', t => {
   t.isA1Equal('$10:10', { range: { top: 9, left: 0, bottom: 9, right: 16383, $top: true, $left: true, $right: true } });
   t.isA1Equal('$10:$10', { range: { top: 9, left: 0, bottom: 9, right: 16383, $top: true, $bottom: true, $left: true, $right: true } });
 
+  t.isA1Equal('A10:A', { range: { top: 9, left: 0, bottom: 1048575, right: 0, $bottom: true } });
+  t.isA1Equal('A:A10', { range: { top: 0, left: 0, bottom: 9, right: 0, $top: true } });
+  t.isA1Equal('A:A$5', { range: { top: 0, left: 0, bottom: 4, right: 0, $top: true, $bottom: true } });
+  t.isA1Equal('A$5:A', { range: { top: 4, left: 0, bottom: 1048575, right: 0, $top: true, $bottom: true } });
+  t.isA1Equal('A:$B5', { range: { top: 0, left: 0, bottom: 4, right: 1, $top: true, $right: true } });
+  t.isA1Equal('$B:B3', { range: { top: 0, left: 1, bottom: 2, right: 1, $top: true, $left: true } });
+  t.isA1Equal('$B:C5', { range: { top: 0, left: 1, bottom: 4, right: 2, $top: true, $left: true } });
+
+  t.isA1Equal('D1:1', { range: { top: 0, left: 3, bottom: 0, right: 16383, $right: true } });
+  t.isA1Equal('1:D2', { range: { top: 0, left: 0, bottom: 1, right: 3, $left: true } });
+  t.isA1Equal('2:$D3', { range: { top: 1, left: 0, bottom: 2, right: 3, $left: true, $right: true } });
+  t.isA1Equal('$D2:3', { range: { top: 1, left: 3, bottom: 2, right: 16383, $left: true, $right: true } });
+  t.isA1Equal('1:D$1', { range: { top: 0, left: 0, bottom: 0, right: 3, $left: true, $bottom: true } });
+  t.isA1Equal('$1:D1', { range: { top: 0, left: 0, bottom: 0, right: 3, $left: true, $top: true } });
+  t.isA1Equal('AA$3:4', { range: { top: 2, left: 26, bottom: 3, right: 16383, $right: true, $top: true } });
+
   t.isA1Equal('XFD1048576', { range: { top: 1048575, left: 16383, bottom: 1048575, right: 16383 } });
 
   t.isA1Equal('Sheet1!A1', {

--- a/lib/a1-test.js
+++ b/lib/a1-test.js
@@ -86,6 +86,11 @@ test('parse A1 references', t => {
   t.isA1Equal('$1:D1', { range: { top: 0, left: 0, bottom: 0, right: 3, $left: true, $top: true } });
   t.isA1Equal('AA$3:4', { range: { top: 2, left: 26, bottom: 3, right: 16383, $right: true, $top: true } });
 
+  t.isA1Equal('B3:2', { range: { top: 1, bottom: 2, left: 1, right: 16383, $right: true } });
+  t.isA1Equal('3:B2', { range: { top: 1, bottom: 2, left: 0, right: 1, $left: true } });
+  t.isA1Equal('C2:B', { range: { top: 1, bottom: 1048575, left: 1, right: 2, $bottom: true } });
+  t.isA1Equal('C:B2', { range: { top: 0, bottom: 1, left: 1, right: 2, $top: true } });
+
   t.isA1Equal('XFD1048576', { range: { top: 1048575, left: 16383, bottom: 1048575, right: 16383 } });
 
   t.isA1Equal('Sheet1!A1', {

--- a/lib/a1.js
+++ b/lib/a1.js
@@ -95,6 +95,39 @@ export function fromA1 (rangeStr) {
     $right = true;
     return { top, left, bottom, right, $top, $left, $bottom, $right };
   }
+  // A1:A
+  else if ((m = /^(\$?)([A-Z]{1,3})((\$?)([1-9]\d{0,6}))?:(\$?)([A-Z]{1,3})((\$?)([1-9]\d{0,6}))?$/.exec(rangeStr))) {
+    // [ "$A$1:$B$2", "$", "A", "$1", "$", "1", "$", "B", "$2", "$",  "2"  ]
+    // [ "A1:A",      "",  "A", "1",  "",  "1", "",  "A", null, null, null ]
+    //   0            1 .  2 .  3 .   4 .  5 .  6 .  7 .  8 .   9 .   10
+
+    const left = fromCol(m[2]);
+    const right = fromCol(m[7]);
+    $left = !!m[1];
+    $right = !!m[6];
+
+    const top = m[5] ? fromRow(m[5]) : 0;
+    const bottom = m[10] ? fromRow(m[10]) : MAX_ROWS;
+    $top = !!m[4];
+    $bottom = !!m[9];
+    return { top, left, bottom, right, $top, $left, $bottom, $right };
+  }
+  else if ((m = /^((\$?)([A-Z]{1,3}))?(\$?)([1-9]\d{0,6}):((\$?)([A-Z]{1,3}))?(\$?)([1-9]\d{0,6})$/.exec(rangeStr))) {
+    // [ "$A$1:$1", "$A", "$",  "A",  "$", "1", null, null, null, "$", "1" ]
+    // [ "1:A1",    null, null, null, "",  "1", "A",  "",   "A",  "",  "1" ]
+    //   0          1     2     3     4    5    6     6     7     8    9
+
+    const left = m[3] ? fromCol(m[3]) : 0;
+    const right = m[7] ? fromCol(m[7]) : MAX_COLS;
+    $left = !!m[2];
+    $right = !!m[6];
+
+    const top = m[5] ? fromRow(m[5]) : 0;
+    const bottom = m[9] ? fromRow(m[9]) : MAX_ROWS;
+    $top = !!m[4];
+    $bottom = !!m[8];
+    return { top, left, bottom, right, $top, $left, $bottom, $right };
+  }
   // A1 | A1:B2
   else {
     const [ part1, part2 ] = rangeStr.split(':');

--- a/lib/a1.js
+++ b/lib/a1.js
@@ -95,7 +95,7 @@ export function fromA1 (rangeStr) {
     $right = true;
     return { top, left, bottom, right, $top, $left, $bottom, $right };
   }
-  // A1:A
+  // A1:A and A:A1
   else if ((m = /^(\$?)([A-Z]{1,3})((\$?)([1-9]\d{0,6}))?:(\$?)([A-Z]{1,3})((\$?)([1-9]\d{0,6}))?$/.exec(rangeStr))) {
     // [ "$A$1:$B$2", "$", "A", "$1", "$", "1", "$", "B", "$2", "$",  "2"  ]
     // [ "A1:A",      "",  "A", "1",  "",  "1", "",  "A", null, null, null ]
@@ -108,24 +108,27 @@ export function fromA1 (rangeStr) {
 
     const top = m[5] ? fromRow(m[5]) : 0;
     const bottom = m[10] ? fromRow(m[10]) : MAX_ROWS;
-    $top = !!m[4];
-    $bottom = !!m[9];
+    $top = m[5] ? !!m[4] : true;
+    $bottom = m[10] ? !!m[9] : true;
     return { top, left, bottom, right, $top, $left, $bottom, $right };
   }
+  // A1:1 and 1:A1
   else if ((m = /^((\$?)([A-Z]{1,3}))?(\$?)([1-9]\d{0,6}):((\$?)([A-Z]{1,3}))?(\$?)([1-9]\d{0,6})$/.exec(rangeStr))) {
     // [ "$A$1:$1", "$A", "$",  "A",  "$", "1", null, null, null, "$", "1" ]
     // [ "1:A1",    null, null, null, "",  "1", "A",  "",   "A",  "",  "1" ]
-    //   0          1     2     3     4    5    6     6     7     8    9
+    // [ "1:D1",    null, null, null, "",  "1", "D",  "",  "D",   "",  "1" ]
+    //   0          1     2     3     4    5    6     7     8     9    10
 
     const left = m[3] ? fromCol(m[3]) : 0;
-    const right = m[7] ? fromCol(m[7]) : MAX_COLS;
-    $left = !!m[2];
-    $right = !!m[6];
+    const right = m[8] ? fromCol(m[8]) : MAX_COLS;
+    $left = m[3] ? !!m[2] : true;
+    $right = m[8] ? !!m[7] : true;
 
-    const top = m[5] ? fromRow(m[5]) : 0;
-    const bottom = m[9] ? fromRow(m[9]) : MAX_ROWS;
+    const top = fromRow(m[5]);
+    const bottom = fromRow(m[10]);
     $top = !!m[4];
-    $bottom = !!m[8];
+    $bottom = !!m[9];
+
     return { top, left, bottom, right, $top, $left, $bottom, $right };
   }
   // A1 | A1:B2

--- a/lib/a1.js
+++ b/lib/a1.js
@@ -97,37 +97,36 @@ export function fromA1 (rangeStr) {
   }
   // A1:A and A:A1
   else if ((m = /^(\$?)([A-Z]{1,3})((\$?)([1-9]\d{0,6}))?:(\$?)([A-Z]{1,3})((\$?)([1-9]\d{0,6}))?$/.exec(rangeStr))) {
-    // [ "$A$1:$B$2", "$", "A", "$1", "$", "1", "$", "B", "$2", "$",  "2"  ]
-    // [ "A1:A",      "",  "A", "1",  "",  "1", "",  "A", null, null, null ]
-    //   0            1 .  2 .  3 .   4 .  5 .  6 .  7 .  8 .   9 .   10
-
-    const left = fromCol(m[2]);
-    const right = fromCol(m[7]);
+    left = fromCol(m[2]);
+    right = fromCol(m[7]);
     $left = !!m[1];
     $right = !!m[6];
 
-    const top = m[5] ? fromRow(m[5]) : 0;
-    const bottom = m[10] ? fromRow(m[10]) : MAX_ROWS;
+    if (right < left) {
+      [ left, right, $left, $right ] = [ right, left, $right, $left ];
+    }
+
+    top = m[5] ? fromRow(m[5]) : 0;
+    bottom = m[10] ? fromRow(m[10]) : MAX_ROWS;
     $top = m[5] ? !!m[4] : true;
     $bottom = m[10] ? !!m[9] : true;
     return { top, left, bottom, right, $top, $left, $bottom, $right };
   }
   // A1:1 and 1:A1
   else if ((m = /^((\$?)([A-Z]{1,3}))?(\$?)([1-9]\d{0,6}):((\$?)([A-Z]{1,3}))?(\$?)([1-9]\d{0,6})$/.exec(rangeStr))) {
-    // [ "$A$1:$1", "$A", "$",  "A",  "$", "1", null, null, null, "$", "1" ]
-    // [ "1:A1",    null, null, null, "",  "1", "A",  "",   "A",  "",  "1" ]
-    // [ "1:D1",    null, null, null, "",  "1", "D",  "",  "D",   "",  "1" ]
-    //   0          1     2     3     4    5    6     7     8     9    10
-
-    const left = m[3] ? fromCol(m[3]) : 0;
-    const right = m[8] ? fromCol(m[8]) : MAX_COLS;
-    $left = m[3] ? !!m[2] : true;
-    $right = m[8] ? !!m[7] : true;
-
-    const top = fromRow(m[5]);
-    const bottom = fromRow(m[10]);
+    top = fromRow(m[5]);
+    bottom = fromRow(m[10]);
     $top = !!m[4];
     $bottom = !!m[9];
+
+    if (bottom < top) {
+      [ top, bottom, $top, $bottom ] = [ bottom, top, $bottom, $top ];
+    }
+
+    left = m[3] ? fromCol(m[3]) : 0;
+    right = m[8] ? fromCol(m[8]) : MAX_COLS;
+    $left = m[3] ? !!m[2] : true;
+    $right = m[8] ? !!m[7] : true;
 
     return { top, left, bottom, right, $top, $left, $bottom, $right };
   }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -87,6 +87,8 @@ export const tokenHandlersRefsA1 = [
   [ PATH_QUOTE,  re_PATH_QUOTE ],
   [ PATH_BRACE,  re_PATH_BRACE ],
   [ PATH_PREFIX, re_PATH_PREFIX ],
+  [ RANGE_BEAM,  re_A1COL_PARTIAL, quickVerifyRangeA1 ],
+  [ RANGE_BEAM,  re_A1ROW_PARTIAL, quickVerifyRangeA1 ],
   [ RANGE,       re_A1RANGE, quickVerifyRangeA1 ],
   [ RANGE_BEAM,  re_A1COL, quickVerifyRangeA1 ],
   [ RANGE_BEAM,  re_A1ROW, quickVerifyRangeA1 ],

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -31,9 +31,7 @@ const re_PATH_QUOTE = /^'(?:''|[^'])*('|$)/;
 const re_PATH_BRACE = /^\[(?:[^\]])+(\]|$)/;
 const re_PATH_PREFIX = /^([^ \t\n$!"`'#%&(){}<>,;:^@|~=*+-]+)(?=!)/; // Sheets: [^:\\/?*[\]]{0,31} (but WB names?)
 const re_A1COL = /^\$?[A-Z]{1,3}:\$?[A-Z]{1,3}/i;
-const re_A1COL_PARTIAL = /^((^\$?[A-Z]{1,3}\$?[1-9][0-9]{0,6}:\$?[A-Z]{1,3}(?!(\$?([1-9][0-9]{0,6})|([A-Z]{1,3}))))|(\$?[A-Z]{1,3}:\$?[A-Z]{1,3}\$?[1-9][0-9]{0,6}))/i;
 const re_A1ROW = /^\$?[1-9][0-9]{0,6}:\$?[1-9][0-9]{0,6}/i;
-const re_A1ROW_PARTIAL = /^((\$?[A-Z]{1,3}\$?[1-9][0-9]{0,6}:\$?[1-9][0-9]{0,6})|(\$?[1-9][0-9]{0,6}:\$?[A-Z]{1,3}\$?[1-9][0-9]{0,6}))/i;
 const re_A1RANGE = /^\$?[A-Z]{1,3}\$?[1-9][0-9]{0,6}/i;
 const rPart = '(?:R(?:\\[[+-]?\\d+\\]|[1-9][0-9]{0,6})?)';
 const cPart = '(?:C(?:\\[[+-]?\\d+\\]|[1-9][0-9]{0,4})?)';
@@ -43,6 +41,24 @@ const re_RCRANGE = new RegExp(`^(?:(?=[RC])${rPart}${cPart})`, 'i');
 const re_NUMBER = /^(?:\d+(\.\d+)?(?:[eE][+-]?\d+)?|\d+)/;
 const re_NAMED = /^[A-Z\d\\_.?]+/i; // FIXME there are stricter rules for this!
 // const re_NAMED = /^(?![RC]$)[A-ZÀ-ȳ_\\][\\?\wÀ-ȳ.]{0,255}$/i;
+
+// Match either A1:A or A:A1, split into two capture groups.
+//
+// When matching A1:A, we include a negative lookahead that prevents
+// matching the A1:A case if the match is followed by:
+//
+//    - digits from 0-9 (prevents matching 'A1:B' for an input string 'A1:B2').
+//
+//    - '(' and '.' (prevents matching 'A1:IF' for an input string 'A1:IF(...)'
+//      and matching 'A1:F' for an input string 'A1:F.DIST(...)').
+//
+//    - characters from A-Z (prevents matching 'A1:I' for an input string
+//      'A1:IF(...)')
+//
+const re_A1COL_PARTIAL = /^((^\$?[A-Z]{1,3}\$?[1-9][0-9]{0,6}:\$?[A-Z]{1,3}(?!(\$?([1-9][0-9]{0,6})|([A-Z\(\.]))))|(\$?[A-Z]{1,3}:\$?[A-Z]{1,3}\$?[1-9][0-9]{0,6}))/i;
+
+// Match either A1:1 or 1:A1, split into two capture groups.
+const re_A1ROW_PARTIAL = /^((\$?[A-Z]{1,3}\$?[1-9][0-9]{0,6}:\$?[1-9][0-9]{0,6})|(\$?[1-9][0-9]{0,6}:\$?[A-Z]{1,3}\$?[1-9][0-9]{0,6}))/i;
 
 export const tokenHandlersA1 = [
   [ ERROR,       re_ERROR ],

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -31,7 +31,9 @@ const re_PATH_QUOTE = /^'(?:''|[^'])*('|$)/;
 const re_PATH_BRACE = /^\[(?:[^\]])+(\]|$)/;
 const re_PATH_PREFIX = /^([^ \t\n$!"`'#%&(){}<>,;:^@|~=*+-]+)(?=!)/; // Sheets: [^:\\/?*[\]]{0,31} (but WB names?)
 const re_A1COL = /^\$?[A-Z]{1,3}:\$?[A-Z]{1,3}/i;
+const re_A1COL_PARTIAL = /^((^\$?[A-Z]{1,3}\$?[1-9][0-9]{0,6}:\$?[A-Z]{1,3}(?!(\$?([1-9][0-9]{0,6})|([A-Z]{1,3}))))|(\$?[A-Z]{1,3}:\$?[A-Z]{1,3}\$?[1-9][0-9]{0,6}))/i;
 const re_A1ROW = /^\$?[1-9][0-9]{0,6}:\$?[1-9][0-9]{0,6}/i;
+const re_A1ROW_PARTIAL = /^((\$?[A-Z]{1,3}\$?[1-9][0-9]{0,6}:\$?[1-9][0-9]{0,6})|(\$?[1-9][0-9]{0,6}:\$?[A-Z]{1,3}\$?[1-9][0-9]{0,6}))/i;
 const re_A1RANGE = /^\$?[A-Z]{1,3}\$?[1-9][0-9]{0,6}/i;
 const rPart = '(?:R(?:\\[[+-]?\\d+\\]|[1-9][0-9]{0,6})?)';
 const cPart = '(?:C(?:\\[[+-]?\\d+\\]|[1-9][0-9]{0,4})?)';
@@ -53,6 +55,8 @@ export const tokenHandlersA1 = [
   [ PATH_QUOTE,  re_PATH_QUOTE ],
   [ PATH_BRACE,  re_PATH_BRACE ],
   [ PATH_PREFIX, re_PATH_PREFIX ],
+  [ RANGE_BEAM,  re_A1COL_PARTIAL, quickVerifyRangeA1 ],
+  [ RANGE_BEAM,  re_A1ROW_PARTIAL, quickVerifyRangeA1 ],
   [ RANGE,       re_A1RANGE, quickVerifyRangeA1 ],
   [ RANGE_BEAM,  re_A1COL, quickVerifyRangeA1 ],
   [ RANGE_BEAM,  re_A1ROW, quickVerifyRangeA1 ],

--- a/lib/lexer-test.js
+++ b/lib/lexer-test.js
@@ -1361,3 +1361,20 @@ test('tokenize strings', t => {
 
   t.end();
 });
+
+test('partial row/col ranges', t => {
+  t.isTokens('A10:A', [
+    { type: RANGE_BEAM, value: 'A10:A' }
+  ]);
+  t.isTokens('A:A10', [
+    { type: RANGE_BEAM, value: 'A:A10' }
+  ]);
+  t.isTokens('A10:12', [
+    { type: RANGE_BEAM, value: 'A10:12' }
+  ]);
+  t.isTokens('1:D1', [
+    { type: RANGE_BEAM, value: '1:D1' }
+  ]);
+
+  t.end();
+});

--- a/lib/lexer-test.js
+++ b/lib/lexer-test.js
@@ -1362,18 +1362,27 @@ test('tokenize strings', t => {
   t.end();
 });
 
-test('partial row/col ranges', t => {
-  t.isTokens('A10:A', [
-    { type: RANGE_BEAM, value: 'A10:A' }
+test('tokenize partial row and column ranges', t => {
+  t.isTokens('=A10:A+B1:2', [
+    { type: FX_PREFIX, value: '=' },
+    { type: RANGE_BEAM, value: 'A10:A' },
+    { type: OPERATOR, value: '+' },
+    { type: RANGE_BEAM, value: 'B1:2' }
   ]);
-  t.isTokens('A:A10', [
-    { type: RANGE_BEAM, value: 'A:A10' }
+  t.isTokens('=SUM(A:A$10,3:B$2)', [
+    { type: FX_PREFIX, value: '=' },
+    { type: FUNCTION, value: 'SUM' },
+    { type: OPERATOR, value: '(' },
+    { type: RANGE_BEAM, value: 'A:A$10' },
+    { type: OPERATOR, value: ',' },
+    { type: RANGE_BEAM, value: '3:B$2' },
+    { type: OPERATOR, value: ')' }
   ]);
-  t.isTokens('A10:12', [
-    { type: RANGE_BEAM, value: 'A10:12' }
+  t.isTokens('$A$10:$12', [
+    { type: RANGE_BEAM, value: '$A$10:$12' }
   ]);
-  t.isTokens('1:D1', [
-    { type: RANGE_BEAM, value: '1:D1' }
+  t.isTokens('1:D$1', [
+    { type: RANGE_BEAM, value: '1:D$1' }
   ]);
 
   t.end();

--- a/lib/lexer-test.js
+++ b/lib/lexer-test.js
@@ -1384,6 +1384,22 @@ test('tokenize partial row and column ranges', t => {
   t.isTokens('1:D$1', [
     { type: RANGE_BEAM, value: '1:D$1' }
   ]);
+  t.isTokens('=A1:IF()', [
+    { type: FX_PREFIX, value: '=' },
+    { type: RANGE, value: 'A1' },
+    { type: OPERATOR, value: ':' },
+    { type: FUNCTION, value: 'IF' },
+    { type: OPERATOR, value: '(' },
+    { type: OPERATOR, value: ')' }
+  ]);
+  t.isTokens('=A1:F.DIST()', [
+    { type: FX_PREFIX, value: '=' },
+    { type: RANGE, value: 'A1' },
+    { type: OPERATOR, value: ':' },
+    { type: FUNCTION, value: 'F.DIST' },
+    { type: OPERATOR, value: '(' },
+    { type: OPERATOR, value: ')' }
+  ]);
 
   t.end();
 });


### PR DESCRIPTION
# What

Add support for `A1:A`, `A:A1`, `1:A1`, and `A1:1` ranges.


# How

## Match `re_A1COL_PARTIAL` and `re_A1ROW_PARTIAL` before `re_A1RANGE`

`re_A1RANGE` matches `A1`, so it can match the prefix of both partial row and column ranges:

 * `A1:A` - partial column range
 * `A1:1` - partial row range

This means that we need to match partial row and column ranges before attempting to match normal ranges.

```tsx
export const tokenHandlersA1 = [
  // ...
  [ RANGE_BEAM,  re_A1COL_PARTIAL, quickVerifyRangeA1 ],
  [ RANGE_BEAM,  re_A1ROW_PARTIAL, quickVerifyRangeA1 ],
  [ RANGE,       re_A1RANGE, quickVerifyRangeA1 ],
  [ RANGE_BEAM,  re_A1COL, quickVerifyRangeA1 ],
  [ RANGE_BEAM,  re_A1ROW, quickVerifyRangeA1 ],
  // ...
];
```

`re_A1COL_PARTIAL` and `re_A1ROW_PARTIAL` regexes both have two capture groups, which can be represented like so (heavily simplified):

```
re_A1COL_PARTIAL = /(A1:A)|(A:A1)/i
re_A1ROW_PARTIAL = /(A1:1)|(1:A1)/i
```

I would have liked to do something like so:

```
re_A1COL_PARTIAL = /A1?:A1?/i
re_A1ROW_PARTIAL = /A?1:A?1/i
```

But this would match normal ranges such as `A1:B2`, so we need to match both partial cases explicitly.

The `re_A1COL_PARTIAL` regex contains a negative lookahead in the `A1:A` case that disallows the match being followed by:

 * the digits 0-9, or
 * `(`, or
 * `.`, or
 * the characters A-Z.

This prevents the following matches:

```
A1:B2
^^^^ - prevented because '2' matches 0-9

A1:IF()
^^^^^ - prevented because '(' matches '('

A1:F.DIST()
^^^^ - prevented because '(' matches '('

A1:IF()
^^^^ - prevented because 'F' matches A-Z
```

This is documented in a comment, and captured in tests.

