### PR TITLE
test: add cases about unquoted workbook prefixes

### DIFF
--- a/lib/a1-test.js
+++ b/lib/a1-test.js
@@ -110,6 +110,20 @@ test('parse A1 references', t => {
     workbookName: 'Workbook.xlsx',
     range: { top: 0, left: 0, bottom: 0, right: 0 }
   });
+
+  t.isA1Equal('[foo bar]Sheet1!A1', {
+    sheetName: 'Sheet1',
+    workbookName: 'foo bar',
+    range: { top: 0, left: 0, bottom: 0, right: 0 }
+  });
+
+  t.isA1Equal('[a "b" c]d!A1', {
+    sheetName: 'd',
+    workbookName: 'a "b" c',
+    range: { top: 0, left: 0, bottom: 0, right: 0 }
+  });
+
+
   t.isA1Equal('0123456789abcdefghijklmnopqrstuvwxyz!A1', null);
 
   t.isA1Equal('[Workbook.xlsx]!A1', null);


### PR DESCRIPTION
Workbook names in unquoted reference prefixes are currently permitted to include spaces and double-quote characters.

Rules about this are not specified in any published grammar, I think. Some other parsers permit it too, though not Excel itself (it gives you the “We found a typo in your formula and tried to correct it to” dialog box). Because of the square brackets it does not cause any lexical ambiguity, so seems harmless.

This just adds test cases to make it clear and to guard against regressions.