### PR TITLE
Fix `r1c2` typo

### DIFF
--- a/lib/translate.js
+++ b/lib/translate.js
@@ -16,7 +16,7 @@ export function translateToRC (fx, anchorCell) {
   const isString = typeof fx === 'string';
 
   const tokens = isString
-    ? tokenize(fx, { emitRanges: false, mergeRanges: false, allowTernary: true, r1c2: false })
+    ? tokenize(fx, { emitRanges: false, mergeRanges: false, allowTernary: true, r1c1: false })
     : fx;
 
   tokens.forEach(token => {


### PR DESCRIPTION
There is no `r1c2` option available on the `tokenize` function, it's likely just a typo for `r1c1`. The `r1c1` option defaults to `false` anyway, so this has/had no effect.