### PR TITLE
Remove second param from `causesBinaryMinus()` call

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -138,7 +138,7 @@ export function getTokens (fx, tokenHandlers, options = {}) {
         if (
           !tail1 ||
           isType(tail1, FX_PREFIX) ||
-          !causesBinaryMinus(tail1, OPERATOR)
+          !causesBinaryMinus(tail1)
         ) {
           const minus = tokens.pop();
           token.value = '-' + tokenValue;


### PR DESCRIPTION
The `causesBinaryMinus` function only takes one argument, so the second is unused/unnecessary.