### PR TITLE
Switch README documentation for `from`/`to` funcs in `a1`/`rc` modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ a1.stringify({
     top: 0,
     left: 0,
     bottom: 1,
-    right: 1
+    right: 1,
     $top: true,
     $left: false,
     $bottom: false,
@@ -254,13 +254,13 @@ a1.addBounds({
 // }
 ```
 
-#### <a name="a1.to" href="#a1.to">#</a> **.to**( _columnString_ )
-
-Parse a simple string reference to an A1 range into a range object ([see above](#a1.parse)). Will accept `A1`, `A2`, `A:A`, or `1:1`.
-
-#### <a name="a1.from" href="#a1.from">#</a> **.from**( _rangeObject_ )
+#### <a name="a1.to" href="#a1.to">#</a> **.to**( _rangeObject_ )
 
 Stringify a range object ([see above](#a1.parse)) into A1 syntax.
+
+#### <a name="a1.from" href="#a1.from">#</a> **.from**( _rangeString_ )
+
+Parse a simple string reference to an A1 range into a range object ([see above](#a1.parse)). Will accept `A1`, `A2`, `A:A`, or `1:1`.
 
 #### <a name="a1.fromCol" href="#a1.fromCol">#</a> **.fromCol**( _columnString_ )
 
@@ -319,10 +319,10 @@ a1.stringify({
 ```
 
 
-#### <a name="rc.from" href="#rc.from">#</a> **.from**( _rangeObject_ )
+#### <a name="rc.from" href="#rc.from">#</a> **.from**( _refString_ )
 
-Stringify a range object ([see above](#rc.parse)) into R1C1 syntax.
-
-#### <a name="rc.to" href="#rc.to">#</a> **.to**( _columnString_ )
 Parse a simple string reference to an R1C1 range into a range object ([see above](#rc.parse)).
 
+#### <a name="rc.to" href="#rc.to">#</a> **.to**( _rangeObject_ )
+
+Stringify a range object ([see above](#rc.parse)) into R1C1 syntax.


### PR DESCRIPTION
The README's documentation on the [`from`](https://github.com/borgar/fx/blob/dc2a76e2bd935a8f831e42293905096dc4516317/lib/a1.js#L107) and [`to`](https://github.com/borgar/fx/blob/dc2a76e2bd935a8f831e42293905096dc4516317/lib/a1.js#L56) functions in the [`a1`](https://github.com/borgar/fx/blob/dc2a76e2bd935a8f831e42293905096dc4516317/lib/a1.js) module appears to be the wrong way round. For example, the docs for `a1.to()` says that it takes a `columnString` argument, and you use the function to

> Parse a simple string reference to an A1 range into a range object (see above). Will accept A1, A2, A:A, or 1:1.

However, it _actually_ takes `range` argument that's expected to be an object, not a string, and it will return a string.

The opposite is true for the `a1.from()` function: it takes a string and returns an object, but the README says you use it to

> Stringify a range object (see above) into A1 syntax.

Example usage:

```js
import { a1 } from "@borgar/fx";

a1.to({ top: 9, bottom: 9, left: 2, right: 2 })
// Returns "C10"

a1.from("C10")
// Returns a range object:
//
//   {
//     top: 9,
//     left: 2,
//     bottom: 9,
//     right: 2,
//     '$top': false,
//     '$left': false,
//     '$bottom': false,
//     '$right': false
//   }
```

The same is true for the [`to`](https://github.com/borgar/fx/blob/dc2a76e2bd935a8f831e42293905096dc4516317/lib/rc.js#L20) and [`from`](https://github.com/borgar/fx/blob/dc2a76e2bd935a8f831e42293905096dc4516317/lib/rc.js#L106) functions in the [`rc`](https://github.com/borgar/fx/blob/dc2a76e2bd935a8f831e42293905096dc4516317/lib/rc.js) module.

I think all that's happened here is that the documentation for the two `to` functions has been included in the README under the `from` functions, and vice versa.