### PR TITLE
Use correct default value for withLocations in parse function JSDoc

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -486,7 +486,7 @@ prefix('{', function () {
  * @param {boolean} [options.permitArrayRanges=false]  Ranges are allowed as elements of arrays. This is a feature in Google Sheets while Excel does not allow it.
  * @param {boolean} [options.permitArrayCalls=false]  Function calls are allowed as elements of arrays. This is a feature in Google Sheets while Excel does not allow it.
  * @param {boolean} [options.r1c1=false]  Ranges are expected to be in the R1C1 style format rather than the more popular A1 style.
- * @param {boolean} [options.withLocation=true]  Nodes will include source position offsets to the tokens: `{ loc: [ start, end ] }`
+ * @param {boolean} [options.withLocation=false]  Nodes will include source position offsets to the tokens: `{ loc: [ start, end ] }`
  * @return {Object} An AST of nodes
  */
 export function parse (source, options) {


### PR DESCRIPTION
The JSDoc for the `parse` function in `lib/parser.js` gives the default value for its `withLocations` option as `true`, but in actual fact [the default value is `false`](https://github.com/borgar/fx/blob/389900f3e010d9a1374fef7a6a461cfb650faabb/lib/lexer.js#L18). This is a quick correction to update the JSDoc.