### PR TITLE
types: convey location guarantee in return types

### DIFF
--- a/convey-loc-guarantee-in-types.patch
+++ b/convey-loc-guarantee-in-types.patch
@@ -1,0 +1,59 @@
+diff --git a/dist/fx.d.ts b/dist/fx.d.ts
+index a4485ca..23f8bc2 100644
+--- a/dist/fx.d.ts
++++ b/dist/fx.d.ts
+@@ -66,12 +66,12 @@ export declare function addA1RangeBounds(range: RangeA1): RangeA1;
+  * @param [context.workbookName=''] An implied workbook name ('report.xlsx')
+  * @returns The input array with the enchanced tokens
+  */
+-export declare function addTokenMeta(tokenlist: Array<Token>, context?: {
++export declare function addTokenMeta<T extends Token>(tokenlist: Array<T>, context?: {
+     /** An implied sheet name ('Sheet1') */
+     sheetName?: string;
+     /** An implied workbook name ('report.xlsx') */
+     workbookName?: string;
+-}): Array<TokenEnhanced>;
++}): Array<T & TokenEnhanced>;
+ 
+ /**
+  * Normalizes A1 style ranges and structured references in a formula or list of
+@@ -252,7 +252,7 @@ export declare function mergeRefTokens(tokenlist: Array<Token>): Array<Token>;
+  * @param [options.xlsx=false] Switches to the `[1]Sheet1!A1` or `[1]!name` prefix syntax form for external workbooks. See: [Prefixes.md](./Prefixes.md)
+  * @returns An AST of nodes
+  */
+-export declare function parse(formula: (string | Array<Token>), options?: {
++export declare function parse<WithLoc extends boolean = true>(formula: (string | Array<Token>), options?: {
+     /** Enable parsing names as well as ranges. */
+     allowNamed?: boolean;
+     /** Enables the recognition of ternary ranges in the style of `A1:A` or `A1:1`. These are supported by Google Sheets but not Excel. See: References.md. */
+@@ -266,7 +266,7 @@ export declare function parse(formula: (string | Array<Token>), options?: {
+     /** Ranges are expected to be in the R1C1 style format rather than the more popular A1 style. */
+     r1c1?: boolean;
+     /** Nodes will include source position offsets to the tokens: `{ loc: [ start, end ] }` */
+-    withLocation?: boolean;
++    withLocation?: WithLoc;
+     /** Switches to the `[1]Sheet1!A1` or `[1]!name` prefix syntax form for external workbooks. See: [Prefixes.md](./Prefixes.md) */
+     xlsx?: boolean;
+ }): object;
+@@ -509,7 +509,7 @@ declare function toR1C1(range: RangeR1C1): string;
+  * @param [options.xlsx=false] Enables a `[1]Sheet1!A1` or `[1]!name` syntax form for external workbooks found only in XLSX files.
+  * @returns An AST of nodes
+  */
+-export declare function tokenize(formula: string, options?: {
++export declare function tokenize<WithLoc extends boolean = true>(formula: string, options?: {
+     /** Enables the recognition of ternary ranges in the style of `A1:A` or `A1:1`. These are supported by Google Sheets but not Excel. See: References.md. */
+     allowTernary?: boolean;
+     /** Should ranges be returned as whole references (`Sheet1!A1:B2`) or as separate tokens for each part: (`Sheet1`,`!`,`A1`,`:`,`B2`). This is the same as calling [`mergeRefTokens`](#mergeRefTokens) */
+@@ -519,10 +519,10 @@ export declare function tokenize(formula: string, options?: {
+     /** Ranges are expected to be in the R1C1 style format rather than the more popular A1 style. */
+     r1c1?: boolean;
+     /** Nodes will include source position offsets to the tokens: `{ loc: [ start, end ] }` */
+-    withLocation?: boolean;
++    withLocation?: WithLoc;
+     /** Enables a `[1]Sheet1!A1` or `[1]!name` syntax form for external workbooks found only in XLSX files. */
+     xlsx?: boolean;
+-}): Array<Token>;
++}): WithLoc extends false ? Array<Token> : Array<Token & { loc: number[] }>;
+ 
+ /**
+  * Translates ranges in a formula or list of tokens from relative R1C1 syntax to

--- a/dist/fx.d.ts
+++ b/dist/fx.d.ts
@@ -66,12 +66,12 @@ export declare function addA1RangeBounds(range: RangeA1): RangeA1;
  * @param [context.workbookName=''] An implied workbook name ('report.xlsx')
  * @returns The input array with the enchanced tokens
  */
-export declare function addTokenMeta(tokenlist: Array<Token>, context?: {
+export declare function addTokenMeta<T extends Token>(tokenlist: Array<T>, context?: {
     /** An implied sheet name ('Sheet1') */
     sheetName?: string;
     /** An implied workbook name ('report.xlsx') */
     workbookName?: string;
-}): Array<TokenEnhanced>;
+}): Array<T & TokenEnhanced>;
 
 /**
  * Normalizes A1 style ranges and structured references in a formula or list of
@@ -252,7 +252,7 @@ export declare function mergeRefTokens(tokenlist: Array<Token>): Array<Token>;
  * @param [options.xlsx=false] Switches to the `[1]Sheet1!A1` or `[1]!name` prefix syntax form for external workbooks. See: [Prefixes.md](./Prefixes.md)
  * @returns An AST of nodes
  */
-export declare function parse(formula: (string | Array<Token>), options?: {
+export declare function parse<WithLoc extends boolean = true>(formula: (string | Array<Token>), options?: {
     /** Enable parsing names as well as ranges. */
     allowNamed?: boolean;
     /** Enables the recognition of ternary ranges in the style of `A1:A` or `A1:1`. These are supported by Google Sheets but not Excel. See: References.md. */
@@ -266,7 +266,7 @@ export declare function parse(formula: (string | Array<Token>), options?: {
     /** Ranges are expected to be in the R1C1 style format rather than the more popular A1 style. */
     r1c1?: boolean;
     /** Nodes will include source position offsets to the tokens: `{ loc: [ start, end ] }` */
-    withLocation?: boolean;
+    withLocation?: WithLoc;
     /** Switches to the `[1]Sheet1!A1` or `[1]!name` prefix syntax form for external workbooks. See: [Prefixes.md](./Prefixes.md) */
     xlsx?: boolean;
 }): object;
@@ -509,7 +509,7 @@ declare function toR1C1(range: RangeR1C1): string;
  * @param [options.xlsx=false] Enables a `[1]Sheet1!A1` or `[1]!name` syntax form for external workbooks found only in XLSX files.
  * @returns An AST of nodes
  */
-export declare function tokenize(formula: string, options?: {
+export declare function tokenize<WithLoc extends boolean = true>(formula: string, options?: {
     /** Enables the recognition of ternary ranges in the style of `A1:A` or `A1:1`. These are supported by Google Sheets but not Excel. See: References.md. */
     allowTernary?: boolean;
     /** Should ranges be returned as whole references (`Sheet1!A1:B2`) or as separate tokens for each part: (`Sheet1`,`!`,`A1`,`:`,`B2`). This is the same as calling [`mergeRefTokens`](#mergeRefTokens) */
@@ -519,10 +519,10 @@ export declare function tokenize(formula: string, options?: {
     /** Ranges are expected to be in the R1C1 style format rather than the more popular A1 style. */
     r1c1?: boolean;
     /** Nodes will include source position offsets to the tokens: `{ loc: [ start, end ] }` */
-    withLocation?: boolean;
+    withLocation?: WithLoc;
     /** Enables a `[1]Sheet1!A1` or `[1]!name` syntax form for external workbooks found only in XLSX files. */
     xlsx?: boolean;
-}): Array<Token>;
+}): WithLoc extends false ? Array<Token> : Array<Token & { loc: number[] }>;
 
 /**
  * Translates ranges in a formula or list of tokens from relative R1C1 syntax to

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "version": "npm run build",
     "lint": "eslint lib/*.js",
     "test": "tape lib/*.spec.js | tap-min",
-    "build:types": "jsdoc -c tsd.json lib>dist/fx.d.ts",
+    "build:types": "jsdoc -c tsd.json lib>dist/fx.d.ts && patch dist/fx.d.ts convey-loc-guarantee-in-types.patch",
     "build:docs": "echo '# _Fx_ API\n'>docs/API.md; jsdoc -t node_modules/@borgar/jsdoc-tsmd -d console lib>>docs/API.md",
     "build": "NODE_ENV=production rollup -c"
   },


### PR DESCRIPTION
What
---

When `tokenize` is called with `withLocation: true` (or without `withLocation`, since `true` is the default), make the return type convey that the `loc` property of returned tokens will not be `undefined`.

Add the same type parameter on `parse` although its return type is currently just `object` (so it's there if/when that return type gets fleshed out).

Type-parametrize `addTokenMeta` so that this token type information is not lost when `tokenize` results are passed through it.

How
---

Make the required type changes after jsdoc emits types, using a patch file, since jsdoc does not support type expressions, and [does not seem likely to do so in the future][1]. This lets us deliver this type improvement without the effort of switching tooling for generating the types.

The patch will hopefully not conflict very often with future changes in Fx, as these signatures will probably not change very often But if it does, that will not go unnoticed as the `build:types` run-script will fail. If/when that happens, one can just manually edit `dist/fx.d.ts` and regenerate the patch with `git diff dist/fx.d.ts > convey-loc-guarantee-in-types.patch`.

[1]: https://github.com/jsdoc/jsdoc/issues/1917