### PR TITLE
Preserve Spaces in Structured Reference Column Headers

### DIFF
--- a/lib/fixRanges.spec.js
+++ b/lib/fixRanges.spec.js
@@ -135,7 +135,8 @@ test('fixRanges structured references', t => {
   t.isFixed('[[#all],[#all],[#all],[#all],[ColumnName]]', '[[#All],[ColumnName]]');
   t.isFixed('[@[foo]:bar]', '[@[foo]:[bar]]');
   t.isFixed('[@foo bar]', '[@[foo bar]]');
-  t.isFixed('[ @foo bar ]', '[@[foo bar]]');
+  // should not mess with spaces in column headers
+  t.isFixed('[ @foo bar ]', '[@[foo bar ]]');
   t.end();
 });
 

--- a/lib/fixRanges.spec.js
+++ b/lib/fixRanges.spec.js
@@ -137,6 +137,7 @@ test('fixRanges structured references', t => {
   t.isFixed('[@foo bar]', '[@[foo bar]]');
   // should not mess with spaces in column headers
   t.isFixed('[ @foo bar ]', '[@[foo bar ]]');
+  t.isFixed('[ @ foo bar ]', '[@[ foo bar ]]');
   t.end();
 });
 

--- a/lib/sr.js
+++ b/lib/sr.js
@@ -71,7 +71,7 @@ export function parseSRange (raw) {
     // [column]
     else if ((m1 = matchColumn(s, false))) {
       pos += m1[0].length;
-      columns.push(m1[1].trim());
+      columns.push(m1[1]);
     }
     // use the "normal" method
     // [[#keyword]]
@@ -126,7 +126,7 @@ export function parseSRange (raw) {
       const leftCol = expect_more ? matchColumn(raw.slice(pos)) : null;
       if (leftCol) {
         pos += leftCol[0].length;
-        columns.push(leftCol[1].trim());
+        columns.push(leftCol[1]);
         s = raw.slice(pos);
         if (s[0] === ':') {
           s = s.slice(1);
@@ -134,7 +134,7 @@ export function parseSRange (raw) {
           const rightCol = matchColumn(s);
           if (rightCol) {
             pos += rightCol[0].length;
-            columns.push(rightCol[1].trim());
+            columns.push(rightCol[1]);
           }
           else {
             return null;

--- a/lib/sr.spec.js
+++ b/lib/sr.spec.js
@@ -45,6 +45,19 @@ test('parse structured references', t => {
     columns: [ 'my column' ]
   });
 
+  t.isSREqual('[ [my column]:otherColumn]', {
+    columns: [ 'my column', 'otherColumn' ]
+  });
+
+  t.isSREqual('[ @[my column]:otherColumn]', {
+    columns: [ 'my column', 'otherColumn' ],
+    sections: [ 'this row' ]
+  });
+
+  t.isSREqual('[ [#Data], [my column]:otherColumn]', {
+    columns: [ 'my column', 'otherColumn' ],
+    sections: [ 'data' ]
+  });
 
   t.isSREqual('[ [#Data], [my column]:[\'@foo] ]', {
     columns: [ 'my column', '@foo' ],
@@ -83,18 +96,13 @@ test('parse structured references', t => {
   });
 
   // should not mess with spaces in column headers
-  t.isSREqual('[ [my column]:otherColumn ]', {
-    columns: [ 'my column', 'otherColumn ' ]
+  t.isSREqual('[ [ my column ]: otherColumn ]', {
+    columns: [ ' my column ', ' otherColumn ' ]
   });
 
   t.isSREqual('[ @[my column]:otherColumn ]', {
     columns: [ 'my column', 'otherColumn ' ],
     sections: [ 'this row' ]
-  });
-
-  t.isSREqual('[ [#Data], [my column]:otherColumn ]', {
-    columns: [ 'my column', 'otherColumn ' ],
-    sections: [ 'data' ]
   });
 
   t.end();

--- a/lib/sr.spec.js
+++ b/lib/sr.spec.js
@@ -45,19 +45,6 @@ test('parse structured references', t => {
     columns: [ 'my column' ]
   });
 
-  t.isSREqual('[ [my column]:otherColumn ]', {
-    columns: [ 'my column', 'otherColumn' ]
-  });
-
-  t.isSREqual('[ @[my column]:otherColumn ]', {
-    columns: [ 'my column', 'otherColumn' ],
-    sections: [ 'this row' ]
-  });
-
-  t.isSREqual('[ [#Data], [my column]:otherColumn ]', {
-    columns: [ 'my column', 'otherColumn' ],
-    sections: [ 'data' ]
-  });
 
   t.isSREqual('[ [#Data], [my column]:[\'@foo] ]', {
     columns: [ 'my column', '@foo' ],
@@ -93,6 +80,21 @@ test('parse structured references', t => {
     table: 'TMP8w0habhr',
     context: [ 'myworkbook.xlsx', 'Sheet1' ],
     sections: [ 'all' ]
+  });
+
+  // should not mess with spaces in column headers
+  t.isSREqual('[ [my column]:otherColumn ]', {
+    columns: [ 'my column', 'otherColumn ' ]
+  });
+
+  t.isSREqual('[ @[my column]:otherColumn ]', {
+    columns: [ 'my column', 'otherColumn ' ],
+    sections: [ 'this row' ]
+  });
+
+  t.isSREqual('[ [#Data], [my column]:otherColumn ]', {
+    columns: [ 'my column', 'otherColumn ' ],
+    sections: [ 'data' ]
   });
 
   t.end();


### PR DESCRIPTION
This PR proposes an enhancement to the @borgar/fx library to align its handling of structured reference column headers with Excel's standards. In Excel, leading and trailing spaces in column headers are preserved. 

Currently, the library automatically trims these spaces, which can lead to discrepancies for users expecting Excel-like behavior. 