### PR TITLE
Fix handling of R and C tokens within LET() and LAMBDA()

### DIFF
--- a/lib/isRCTokenValue.ts
+++ b/lib/isRCTokenValue.ts
@@ -1,0 +1,3 @@
+export function isRCTokenValue (value: string): boolean {
+  return value === 'r' || value === 'R' || value === 'c' || value === 'C';
+}

--- a/lib/tokenize.spec.ts
+++ b/lib/tokenize.spec.ts
@@ -2100,4 +2100,76 @@ describe('lexer', () => {
     expect(tokenizeXlsx('[foo]!A1')).toEqual([ { type: REF_RANGE, value: '[foo]!A1' } ]);
     expect(tokenizeXlsx('foo!A1')).toEqual([ { type: REF_RANGE, value: 'foo!A1' } ]);
   });
+
+  test('r and c as LET arguments in R1C1 mode', () => {
+    // Unlike with LET(c,1,c) is not valid syntax with the R1C1 notation in Excel.
+    //
+    // If you create a cell with this expression in A1 mode and flip to R1C1, Excel
+    // will not change it when expressing it, but will not allow you to re-enter it.
+    //
+    // Excel will always save the formula such as the arguments will have a "_xlpm."
+    // prefix: _xlfn.LET(_xlpm.c,1,_xlpm.c)
+    //
+    // However, that is also invalid syntax in the exposed/common Excel formula syntax.
+    // To counter this, fx does the following:
+    //
+    // tokenize:
+    //    Supports _xlpm.c in both modes.
+    //    Assumes c, C, r and R are names when encountered as tokens within LET functions.
+    // translateTokensToR1C1:
+    //    Tries to be unabiguous by serializing "c" ranges in within LET as C[0].
+    //    Same goes for "r" to R[0]. Prefixed names are left as they are.
+    //    This way round-tripping is possible.
+    expect(tokenize('LET(c,1,c)', { r1c1: true })).toEqual([
+      { type: FUNCTION, value: 'LET' },
+      { type: OPERATOR, value: '(' },
+      { type: REF_NAMED, value: 'c' },
+      { type: OPERATOR, value: ',' },
+      { type: NUMBER, value: '1' },
+      { type: OPERATOR, value: ',' },
+      { type: REF_NAMED, value: 'c' },
+      { type: OPERATOR, value: ')' }
+    ]);
+    expect(tokenize('LET(r,1,r)', { r1c1: true })).toEqual([
+      { type: FUNCTION, value: 'LET' },
+      { type: OPERATOR, value: '(' },
+      { type: REF_NAMED, value: 'r' },
+      { type: OPERATOR, value: ',' },
+      { type: NUMBER, value: '1' },
+      { type: OPERATOR, value: ',' },
+      { type: REF_NAMED, value: 'r' },
+      { type: OPERATOR, value: ')' }
+    ]);
+    // Even if the second C could be identified as a range,
+    // which requires a parse-tree of some sort, the the "c+C"
+    // would both have to be names as arguments are
+    // case-insensitive:
+    expect(tokenize('LET(c,C,c+C)', { r1c1: true })).toEqual([
+      { type: FUNCTION, value: 'LET' },
+      { type: OPERATOR, value: '(' },
+      { type: REF_NAMED, value: 'c' },
+      { type: OPERATOR, value: ',' },
+      { type: REF_NAMED, value: 'C' }, // beam
+      { type: OPERATOR, value: ',' },
+      { type: REF_NAMED, value: 'c' },
+      { type: OPERATOR, value: '+' },
+      { type: REF_NAMED, value: 'C' }, // beam
+      { type: OPERATOR, value: ')' }
+    ]);
+    expect(tokenize('LET(c,C,SUM(c,C))', { r1c1: true })).toEqual([
+      { type: FUNCTION, value: 'LET' },
+      { type: OPERATOR, value: '(' },
+      { type: REF_NAMED, value: 'c' },
+      { type: OPERATOR, value: ',' },
+      { type: REF_NAMED, value: 'C' },
+      { type: OPERATOR, value: ',' },
+      { type: FUNCTION, value: 'SUM' },
+      { type: OPERATOR, value: '(' },
+      { type: REF_NAMED, value: 'c' },
+      { type: OPERATOR, value: ',' },
+      { type: REF_NAMED, value: 'C' },
+      { type: OPERATOR, value: ')' },
+      { type: OPERATOR, value: ')' }
+    ]);
+  });
 });

--- a/lib/tokenize.ts
+++ b/lib/tokenize.ts
@@ -169,12 +169,8 @@ export function getTokens (fx: string, tokenHandlers: PartLexer[], options: Opts
     // It seemse unlikely that anyone does `F2 = LET(c,1,c+F:F)` as this is a
     // circular reference (and not a very useful one), so we're assuming that
     // all "c" or "r" tokens found within the LET are names.
-    if (token.value.length === 1 && (
-      token.type === UNKNOWN ||
-      (opts.r1c1 && token.type === REF_BEAM)
-    )) {
-      const valLC = token.value.toLowerCase();
-      unknownRC += (valLC === 'r' || valLC === 'c') ? 1 : 0;
+    if (token.value.length === 1 && (token.type === UNKNOWN || (opts.r1c1 && token.type === REF_BEAM))) {
+      unknownRC += isRCTokenValue(token.value) ? 1 : 0;
     }
 
     if (negativeNumbers && token.type === NUMBER) {

--- a/lib/tokenize.ts
+++ b/lib/tokenize.ts
@@ -8,11 +8,13 @@ import {
   WHITESPACE,
   FUNCTION,
   OPERATOR_TRIM,
-  REF_RANGE
+  REF_RANGE,
+  REF_BEAM
 } from './constants.ts';
 import { mergeRefTokens } from './mergeRefTokens.ts';
 import { lexers, type PartLexer } from './lexers/sets.ts';
 import type { Token } from './types.ts';
+import { isRCTokenValue } from './isRCTokenValue.ts';
 
 const reLetLambda = /^l(?:ambda|et)$/i;
 const isType = (t: Token, type: string) => t && t.type === type;
@@ -27,12 +29,13 @@ const causesBinaryMinus = (token: Token) => {
   );
 };
 
-function fixRCNames (tokens: Token[]): Token[] {
+function fixRCNames (tokens: Token[], r1c1Mode?: boolean): Token[] {
   let withinCall = 0;
   let parenDepth = 0;
   let lastToken: Token;
   for (const token of tokens) {
-    if (token.type === OPERATOR) {
+    const tokenType = token.type;
+    if (tokenType === OPERATOR) {
       if (token.value === '(') {
         parenDepth++;
         if (lastToken.type === FUNCTION) {
@@ -48,7 +51,10 @@ function fixRCNames (tokens: Token[]): Token[] {
         }
       }
     }
-    else if (withinCall && token.type === UNKNOWN && /^[rc]$/.test(token.value)) {
+    else if (withinCall && tokenType === UNKNOWN && isRCTokenValue(token.value)) {
+      token.type = REF_NAMED;
+    }
+    else if (withinCall && r1c1Mode && tokenType === REF_BEAM && isRCTokenValue(token.value)) {
       token.type = REF_NAMED;
     }
     lastToken = token;
@@ -159,8 +165,14 @@ export function getTokens (fx: string, tokenHandlers: PartLexer[], options: Opts
         letOrLambda++;
       }
     }
-    // make a note if we found a R or C unknown
-    if (token.type === UNKNOWN && token.value.length === 1) {
+    // Make a note if we found a R or C unknown or REF_BEAM token in R1C1 mode.
+    // It seemse unlikely that anyone does `F2 = LET(c,1,c+F:F)` as this is a
+    // circular reference (and not a very useful one), so we're assuming that
+    // all "c" or "r" tokens found within the LET are names.
+    if (token.value.length === 1 && (
+      token.type === UNKNOWN ||
+      (opts.r1c1 && token.type === REF_BEAM)
+    )) {
       const valLC = token.value.toLowerCase();
       unknownRC += (valLC === 'r' || valLC === 'c') ? 1 : 0;
     }
@@ -195,7 +207,7 @@ export function getTokens (fx: string, tokenHandlers: PartLexer[], options: Opts
   // if we encountered both a LAMBDA/LET call, and unknown 'r' or 'c' tokens
   // we'll turn the unknown tokens into names within the call.
   if (unknownRC && letOrLambda) {
-    fixRCNames(tokens);
+    fixRCNames(tokens, opts.r1c1);
   }
 
   // Any OPERATOR_TRIM tokens have been indexed already, they now need to be

--- a/lib/translateToA1.spec.ts
+++ b/lib/translateToA1.spec.ts
@@ -247,8 +247,7 @@ describe('translate works with trimmed ranges', () => {
 });
 
 describe('translate r & c as LET parameters', () => {
-  // Unlike with LET(c,1,c) is not valid syntax with the R1C1 notation in Excel.
-  //
+  // Unlike in A1, LET(c,1,c) is not valid syntax with the R1C1 notation in Excel.
   // If you create a cell with this expression in A1 mode and flip to R1C1, Excel
   // will not change it when expressing it, but will not allow you to re-enter it.
   //

--- a/lib/translateToA1.spec.ts
+++ b/lib/translateToA1.spec.ts
@@ -261,7 +261,7 @@ describe('translate r & c as LET parameters', () => {
   //    Supports _xlpm.c in both modes.
   //    Assumes c, C, r and R are names when encountered as tokens within LET functions.
   // translateTokensToR1C1:
-  //    Tries to be unabiguous by serializing "c" ranges in within LET as C[0].
+  //    Tries to be unambiguous by serializing "c" ranges in within LET as C[0].
   //    Same goes for "r" to R[0]. Prefixed names are left as they are.
   //    This way round-tripping is possible.
   function testExpr (expr: string, anchor: string, expected: any[]) {

--- a/lib/translateToA1.spec.ts
+++ b/lib/translateToA1.spec.ts
@@ -245,3 +245,88 @@ describe('translate works with trimmed ranges', () => {
     ]);
   });
 });
+
+describe('translate r & c as LET parameters', () => {
+  // Unlike with LET(c,1,c) is not valid syntax with the R1C1 notation in Excel.
+  //
+  // If you create a cell with this expression in A1 mode and flip to R1C1, Excel
+  // will not change it when expressing it, but will not allow you to re-enter it.
+  //
+  // Excel will always save the formula such as the arguments will have a "_xlpm."
+  // prefix: _xlfn.LET(_xlpm.c,1,_xlpm.c)
+  //
+  // However, that is also invalid syntax in the exposed/common Excel formula syntax.
+  // To counter this, fx does the following:
+  //
+  // tokenize:
+  //    Supports _xlpm.c in both modes.
+  //    Assumes c, C, r and R are names when encountered as tokens within LET functions.
+  // translateTokensToR1C1:
+  //    Tries to be unabiguous by serializing "c" ranges in within LET as C[0].
+  //    Same goes for "r" to R[0]. Prefixed names are left as they are.
+  //    This way round-tripping is possible.
+  function testExpr (expr: string, anchor: string, expected: any[]) {
+    const opts = { mergeRefs: true, r1c1: true };
+    expect(translateTokensToA1(tokenizeXlsx(expr, opts), anchor)).toEqual(expected);
+  }
+
+  test('translate prefixed r & c in LET', () => {
+    testExpr('_xlfn.LET(_xlpm.c,3,_xlpm.c)', 'B2', [
+      { type: 'func', value: '_xlfn.LET' },
+      { type: 'operator', value: '(' },
+      { type: 'range_named', value: '_xlpm.c' },
+      { type: 'operator', value: ',' },
+      { type: 'number', value: '3' },
+      { type: 'operator', value: ',' },
+      { type: 'range_named', value: '_xlpm.c' },
+      { type: 'operator', value: ')' }
+    ]);
+
+    testExpr('_xlfn.LET(_xlpm.r,3,_xlpm.r)', 'B2', [
+      { type: 'func', value: '_xlfn.LET' },
+      { type: 'operator', value: '(' },
+      { type: 'range_named', value: '_xlpm.r' },
+      { type: 'operator', value: ',' },
+      { type: 'number', value: '3' },
+      { type: 'operator', value: ',' },
+      { type: 'range_named', value: '_xlpm.r' },
+      { type: 'operator', value: ')' }
+    ]);
+  });
+
+  test('Converting ', () => {
+    // The syntax is invalid so it will regress:
+    isR2A('=LET(r,R,r+R)', 'B4', '=LET(r,R,r+R)');
+    isR2A('=LET(c,C,c+C)', 'B4', '=LET(c,C,c+C)');
+    // R[0] and C[0] work as expected
+    isR2A('=LET(r,R[0],r+R[0])', 'B4', '=LET(r,4:4,r+4:4)');
+    isR2A('=LET(c,C[0],c+C[0])', 'B4', '=LET(c,B:B,c+B:B)');
+    // prefixed parameters work too
+    isR2A('=LET(_xlpm.r,R[0],_xlpm.r+R[0])', 'B4', '=LET(_xlpm.r,4:4,_xlpm.r+4:4)');
+    isR2A('=LET(_xlpm.c,C[0],_xlpm.c+C[0])', 'B4', '=LET(_xlpm.c,B:B,_xlpm.c+B:B)');
+  });
+
+  test('translate r & c in LET', () => {
+    testExpr('LET(c,3,c)', 'B2', [
+      { type: 'func', value: 'LET' },
+      { type: 'operator', value: '(' },
+      { type: 'range_named', value: 'c' },
+      { type: 'operator', value: ',' },
+      { type: 'number', value: '3' },
+      { type: 'operator', value: ',' },
+      { type: 'range_named', value: 'c' },
+      { type: 'operator', value: ')' }
+    ]);
+
+    testExpr('LET(r,3,r)', 'B2', [
+      { type: 'func', value: 'LET' },
+      { type: 'operator', value: '(' },
+      { type: 'range_named', value: 'r' },
+      { type: 'operator', value: ',' },
+      { type: 'number', value: '3' },
+      { type: 'operator', value: ',' },
+      { type: 'range_named', value: 'r' },
+      { type: 'operator', value: ')' }
+    ]);
+  });
+});

--- a/lib/translateToA1.ts
+++ b/lib/translateToA1.ts
@@ -103,49 +103,51 @@ export function translateTokensToA1 (
       // We can get away with using the xlsx ref-parser here because it is more permissive
       // and we will end up with the same prefix after serialization anyway:
       const ref = parseR1C1RefXlsx(tokenValue, REF_OPTS) as ReferenceR1C1Xlsx;
-      const d = ref.range;
-      const range: RangeA1 = { top: 0, left: 0 };
-      const r0 = toFixed(d.r0, d.$r0, top, MAX_ROWS, wrapEdges);
-      const r1 = toFixed(d.r1, d.$r1, top, MAX_ROWS, wrapEdges);
-      if (r0 > r1) {
-        range.top = r1;
-        range.$top = d.$r1;
-        range.bottom = r0;
-        range.$bottom = d.$r0;
-      }
-      else {
-        range.top = r0;
-        range.$top = d.$r0;
-        range.bottom = r1;
-        range.$bottom = d.$r1;
-      }
-      const c0 = toFixed(d.c0, d.$c0, left, MAX_COLS, wrapEdges);
-      const c1 = toFixed(d.c1, d.$c1, left, MAX_COLS, wrapEdges);
-      if (c0 > c1) {
-        range.left = c1;
-        range.$left = d.$c1;
-        range.right = c0;
-        range.$right = d.$c0;
-      }
-      else {
-        range.left = c0;
-        range.$left = d.$c0;
-        range.right = c1;
-        range.$right = d.$c1;
-      }
-      if (d.trim) {
-        range.trim = d.trim;
-      }
-      if (isNaN(r0) || isNaN(r1) || isNaN(c0) || isNaN(c1)) {
-        // convert to ref error
-        token.type = ERROR;
-        token.value = '#REF!';
-        delete token.groupId;
-      }
-      else {
-        ref.range = range;
-        // @ts-expect-error -- reusing the object, switching it to A1 by swapping the range
-        token.value = stringifyA1RefXlsx(ref);
+      if (ref) {
+        const d = ref.range;
+        const range: RangeA1 = { top: 0, left: 0 };
+        const r0 = toFixed(d.r0, d.$r0, top, MAX_ROWS, wrapEdges);
+        const r1 = toFixed(d.r1, d.$r1, top, MAX_ROWS, wrapEdges);
+        if (r0 > r1) {
+          range.top = r1;
+          range.$top = d.$r1;
+          range.bottom = r0;
+          range.$bottom = d.$r0;
+        }
+        else {
+          range.top = r0;
+          range.$top = d.$r0;
+          range.bottom = r1;
+          range.$bottom = d.$r1;
+        }
+        const c0 = toFixed(d.c0, d.$c0, left, MAX_COLS, wrapEdges);
+        const c1 = toFixed(d.c1, d.$c1, left, MAX_COLS, wrapEdges);
+        if (c0 > c1) {
+          range.left = c1;
+          range.$left = d.$c1;
+          range.right = c0;
+          range.$right = d.$c0;
+        }
+        else {
+          range.left = c0;
+          range.$left = d.$c0;
+          range.right = c1;
+          range.$right = d.$c1;
+        }
+        if (d.trim) {
+          range.trim = d.trim;
+        }
+        if (isNaN(r0) || isNaN(r1) || isNaN(c0) || isNaN(c1)) {
+          // convert to ref error
+          token.type = ERROR;
+          token.value = '#REF!';
+          delete token.groupId;
+        }
+        else {
+          ref.range = range;
+          // @ts-expect-error -- reusing the object, switching it to A1 by swapping the range
+          token.value = stringifyA1RefXlsx(ref);
+        }
       }
       // if token includes offsets, those offsets are now likely wrong!
       if (token.loc) {

--- a/lib/translateToR1C1.spec.ts
+++ b/lib/translateToR1C1.spec.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from 'vitest';
 import { translateFormulaToR1C1, translateTokensToR1C1 } from './translateToR1C1.ts';
 import { tokenize } from './tokenize.ts';
 import { addTokenMeta } from './addTokenMeta.ts';
-import { FUNCTION, FX_PREFIX, OPERATOR, REF_RANGE, REF_BEAM, REF_STRUCT } from './constants.ts';
+import { FUNCTION, FX_PREFIX, OPERATOR, REF_RANGE, REF_BEAM, REF_STRUCT, REF_NAMED, NUMBER } from './constants.ts';
 
 function isA2R (expr: string, anchor: string, result: string) {
   expect(translateFormulaToR1C1(expr, anchor)).toBe(result);
@@ -219,9 +219,74 @@ describe('translate works with trimmed ranges', () => {
 
   test('trimmed range translation', () => {
     testExpr('Sheet!A1.:.B2*Sheet2!AZ.:.ZZ', 'B2', [
-      { type: 'range', value: 'Sheet!R[-1]C[-1].:.RC' },
-      { type: 'operator', value: '*' },
-      { type: 'range_beam', value: 'Sheet2!C[50].:.C[700]' }
+      { type: REF_RANGE, value: 'Sheet!R[-1]C[-1].:.RC' },
+      { type: OPERATOR, value: '*' },
+      { type: REF_BEAM, value: 'Sheet2!C[50].:.C[700]' }
+    ]);
+  });
+});
+
+describe('translate does not create invalid LET arguments', () => {
+  // Unlike with LET(c,1,c) is not valid syntax with the R1C1 notation in Excel.
+  //
+  // If you create a cell with this expression in A1 mode and flip to R1C1, Excel
+  // will not change it when expressing it, but will not allow you to re-enter it.
+  //
+  // Excel will always save the formula such as the arguments will have a "_xlpm."
+  // prefix: _xlfn.LET(_xlpm.c,1,_xlpm.c)
+  //
+  // However, that is also invalid syntax in the exposed/common Excel formula syntax.
+  // To counter this, fx does the following:
+  //
+  // tokenize:
+  //    Supports _xlpm.c in both modes.
+  //    Assumes c, C, r and R are names when encountered as tokens within LET functions.
+  // translateTokensToR1C1:
+  //    Tries to be unabiguous by serializing "c" ranges in within LET as C[0].
+  //    Same goes for "r" to R[0]. Prefixed names are left as they are.
+  //    This way round-tripping is possible.
+  function testExpr (expr: string, anchor: string, expected: any[]) {
+    const opts = { mergeRefs: true, xlsx: true, r1c1: false };
+    expect(translateTokensToR1C1(tokenize(expr, opts), anchor)).toEqual(expected);
+  }
+
+  test('preserve C + R argument names', () => {
+    isA2R('=LET(c,1,c)', 'B2', '=LET(c,1,c)');
+    isA2R('=LET(r,1,r)', 'B2', '=LET(r,1,r)');
+    // ensure that we disambiguate C and R ranges
+    isA2R('=LET(c,B:B,c+B:B)', 'B2', '=LET(c,C[0],c+C[0])');
+    isA2R('=LET(r,2:2,r+2:2)', 'B2', '=LET(r,R[0],r+R[0])');
+    // prefixed parameters work too
+    isA2R('=LET(_xlpm.c,1,_xlpm.c)', 'B2', '=LET(_xlpm.c,1,_xlpm.c)');
+    isA2R('=LET(_xlpm.r,1,_xlpm.r)', 'B2', '=LET(_xlpm.r,1,_xlpm.r)');
+
+    testExpr('=LET(c,1,c)', 'B2', [
+      { type: FX_PREFIX, value: '=' },
+      { type: FUNCTION, value: 'LET' },
+      { type: OPERATOR, value: '(' },
+      { type: REF_NAMED, value: 'c' },
+      { type: OPERATOR, value: ',' },
+      { type: NUMBER, value: '1' },
+      { type: OPERATOR, value: ',' },
+      { type: REF_NAMED, value: 'c' },
+      { type: OPERATOR, value: ')' }
+    ]);
+  });
+
+  test('ensure that C + R ranges are unambiguous', () => {
+    isA2R('=LET(c,B:B,c)', 'B2', '=LET(c,C[0],c)');
+    isA2R('=LET(r,2:2,r)', 'B2', '=LET(r,R[0],r)');
+
+    testExpr('=LET(c,B:B,c)', 'B2', [
+      { type: FX_PREFIX, value: '=' },
+      { type: FUNCTION, value: 'LET' },
+      { type: OPERATOR, value: '(' },
+      { type: REF_NAMED, value: 'c' },
+      { type: OPERATOR, value: ',' },
+      { type: REF_BEAM, value: 'C[0]' },
+      { type: OPERATOR, value: ',' },
+      { type: REF_NAMED, value: 'c' },
+      { type: OPERATOR, value: ')' }
     ]);
   });
 });

--- a/lib/translateToR1C1.spec.ts
+++ b/lib/translateToR1C1.spec.ts
@@ -227,8 +227,7 @@ describe('translate works with trimmed ranges', () => {
 });
 
 describe('translate does not create invalid LET arguments', () => {
-  // Unlike with LET(c,1,c) is not valid syntax with the R1C1 notation in Excel.
-  //
+  // Unlike in A1, LET(c,1,c) is not valid syntax with the R1C1 notation in Excel.
   // If you create a cell with this expression in A1 mode and flip to R1C1, Excel
   // will not change it when expressing it, but will not allow you to re-enter it.
   //

--- a/lib/translateToR1C1.spec.ts
+++ b/lib/translateToR1C1.spec.ts
@@ -241,7 +241,7 @@ describe('translate does not create invalid LET arguments', () => {
   //    Supports _xlpm.c in both modes.
   //    Assumes c, C, r and R are names when encountered as tokens within LET functions.
   // translateTokensToR1C1:
-  //    Tries to be unabiguous by serializing "c" ranges in within LET as C[0].
+  //    Tries to be unambiguous by serializing "c" ranges in within LET as C[0].
   //    Same goes for "r" to R[0]. Prefixed names are left as they are.
   //    This way round-tripping is possible.
   function testExpr (expr: string, anchor: string, expected: any[]) {

--- a/lib/translateToR1C1.ts
+++ b/lib/translateToR1C1.ts
@@ -4,8 +4,11 @@ import { parseA1Range } from './parseA1Range.ts';
 import type { RangeR1C1, ReferenceA1Xlsx, Token } from './types.ts';
 import { stringifyTokens } from './stringifyTokens.ts';
 import { cloneToken } from './cloneToken.ts';
-import { REF_BEAM, REF_RANGE, REF_TERNARY } from './constants.ts';
+import { FUNCTION, OPERATOR, REF_BEAM, REF_RANGE, REF_TERNARY } from './constants.ts';
 import { splitContext } from './parseRef.ts';
+import { isRCTokenValue } from './isRCTokenValue.ts';
+
+const reLetLambda = /^l(?:ambda|et)$/i;
 
 const calc = (abs: boolean, vX: number, aX: number): number => {
   if (vX == null) {
@@ -70,33 +73,58 @@ export function translateTokensToR1C1 (
     throw new Error('translateTokensToR1C1 got an invalid anchorCell: ' + anchorCell);
   }
   const { top, left } = anchorRange;
+  let withinCall = 0;
+  let parenDepth = 0;
 
   let offsetSkew = 0;
   const outTokens = [];
   for (let token of tokens) {
     const tokenType = token?.type;
+    if (tokenType === OPERATOR) {
+      if (token.value === '(') {
+        parenDepth++;
+        const lastToken = outTokens.at(-1);
+        if (lastToken.type === FUNCTION) {
+          if (reLetLambda.test(lastToken.value)) {
+            withinCall = parenDepth;
+          }
+        }
+      }
+      else if (token.value === ')') {
+        parenDepth--;
+        if (parenDepth < withinCall) {
+          withinCall = 0;
+        }
+      }
+    }
     if (tokenType === REF_RANGE || tokenType === REF_BEAM || tokenType === REF_TERNARY) {
       token = cloneToken(token);
       const tokenValue = token.value;
       // We can get away with using the xlsx ref-parser here because it is more permissive
       // and we will end up with the same prefix after serialization anyway:
       const ref = quickParseA1(tokenValue);
-      const d = ref.range;
-      const range: RangeR1C1 = {};
-      range.r0 = calc(d.$top, d.top, top);
-      range.r1 = calc(d.$bottom, d.bottom, top);
-      range.c0 = calc(d.$left, d.left, left);
-      range.c1 = calc(d.$right, d.right, left);
-      range.$r0 = d.$top;
-      range.$r1 = d.$bottom;
-      range.$c0 = d.$left;
-      range.$c1 = d.$right;
-      if (d.trim) {
-        range.trim = d.trim;
+      if (ref) {
+        const d = ref.range;
+        const range: RangeR1C1 = {};
+        range.r0 = calc(d.$top, d.top, top);
+        range.r1 = calc(d.$bottom, d.bottom, top);
+        range.c0 = calc(d.$left, d.left, left);
+        range.c1 = calc(d.$right, d.right, left);
+        range.$r0 = d.$top;
+        range.$r1 = d.$bottom;
+        range.$c0 = d.$left;
+        range.$c1 = d.$right;
+        if (d.trim) {
+          range.trim = d.trim;
+        }
+        // @ts-expect-error -- reusing the object, switching it to R1C1 by swapping the range
+        ref.range = range;
+        let val = stringifyR1C1RefXlsx(ref);
+        if (isRCTokenValue(val) && withinCall) {
+          val += '[0]';
+        }
+        token.value = val;
       }
-      // @ts-expect-error -- reusing the object, switching it to R1C1 by swapping the range
-      ref.range = range;
-      token.value = stringifyR1C1RefXlsx(ref);
       // if token includes offsets, those offsets are now likely wrong!
       if (token.loc) {
         token.loc[0] += offsetSkew;

--- a/lib/translateToR1C1.ts
+++ b/lib/translateToR1C1.ts
@@ -77,14 +77,14 @@ export function translateTokensToR1C1 (
   let parenDepth = 0;
 
   let offsetSkew = 0;
-  const outTokens = [];
+  const outTokens: Token[] = [];
   for (let token of tokens) {
     const tokenType = token?.type;
     if (tokenType === OPERATOR) {
       if (token.value === '(') {
         parenDepth++;
-        const lastToken = outTokens.at(-1);
-        if (lastToken.type === FUNCTION) {
+        const lastToken = outTokens[outTokens.length - 1];
+        if (lastToken && lastToken.type === FUNCTION) {
           if (reLetLambda.test(lastToken.value)) {
             withinCall = parenDepth;
           }


### PR DESCRIPTION
Unlike in A1, `LET(c,1,c)` is not valid syntax with the R1C1 notation in Excel. If you create a cell with this expression in A1 mode and flip to R1C1, Excel will not change it when expressing it, but will not allow you to re-enter it.

Excel will always save the formula such as the arguments will have a "_xlpm." prefix: `_xlfn.LET(_xlpm.c,1,_xlpm.c)`

However, that is _also_ invalid syntax in the exposed/common Excel formula syntax. To counter this, _fx_ does the following:

* **tokenize():**
    - Supports `_xlpm.` prefixes in both modes.
    - Assumes `c`, `C`, `r` and `R` are names when encountered as tokens within LET functions.

* **translateTokensToR1C1():**
    - Tries to be unambiguous by serializing "c" ranges in within LET as `C[0]`.
    - Same goes for "r" to R[0].
    - Prefixed names are left as they are.

This way round-tripping A1/R1C1 is possible without loss.