### PR TITLE
Prevent multi-cell ranges from being merged

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -14,6 +14,9 @@ export const REF_BEAM = 'range_beam';
 export const REF_TERNARY = 'range_ternary';
 export const REF_NAMED = 'range_named';
 export const REF_STRUCT = 'structured';
+// TODO: in future, we should type the difference between A1:B1 (REF_RANGE) and
+//       A1 (REF_CELL) but this will require a major version bump.
+export const REF_CELL = 'cell'; // internal only
 export const FX_PREFIX = 'fx_prefix';
 export const UNKNOWN = 'unknown';
 

--- a/lib/mergeRefTokens.ts
+++ b/lib/mergeRefTokens.ts
@@ -1,27 +1,29 @@
-import { CONTEXT, CONTEXT_QUOTE, REF_RANGE, REF_NAMED, REF_BEAM, REF_TERNARY, OPERATOR, REF_STRUCT } from './constants.ts';
+import { CONTEXT, CONTEXT_QUOTE, REF_RANGE, REF_NAMED, REF_BEAM, REF_TERNARY, OPERATOR, REF_STRUCT, REF_CELL } from './constants.ts';
 import type { Token } from './types.ts';
 
 const END = '$';
 
 const validRunsMerge = [
-  [ REF_RANGE, ':', REF_RANGE ],
-  [ REF_RANGE, '.:', REF_RANGE ],
-  [ REF_RANGE, ':.', REF_RANGE ],
-  [ REF_RANGE, '.:.', REF_RANGE ],
+  [ REF_CELL, ':', REF_CELL ],
+  [ REF_CELL, '.:', REF_CELL ],
+  [ REF_CELL, ':.', REF_CELL ],
+  [ REF_CELL, '.:.', REF_CELL ],
   [ REF_RANGE ],
   [ REF_BEAM ],
   [ REF_TERNARY ],
-  [ CONTEXT, '!', REF_RANGE, ':', REF_RANGE ],
-  [ CONTEXT, '!', REF_RANGE, '.:', REF_RANGE ],
-  [ CONTEXT, '!', REF_RANGE, ':.', REF_RANGE ],
-  [ CONTEXT, '!', REF_RANGE, '.:.', REF_RANGE ],
+  [ CONTEXT, '!', REF_CELL, ':', REF_CELL ],
+  [ CONTEXT, '!', REF_CELL, '.:', REF_CELL ],
+  [ CONTEXT, '!', REF_CELL, ':.', REF_CELL ],
+  [ CONTEXT, '!', REF_CELL, '.:.', REF_CELL ],
+  [ CONTEXT, '!', REF_CELL ],
   [ CONTEXT, '!', REF_RANGE ],
   [ CONTEXT, '!', REF_BEAM ],
   [ CONTEXT, '!', REF_TERNARY ],
-  [ CONTEXT_QUOTE, '!', REF_RANGE, ':', REF_RANGE ],
-  [ CONTEXT_QUOTE, '!', REF_RANGE, '.:', REF_RANGE ],
-  [ CONTEXT_QUOTE, '!', REF_RANGE, ':.', REF_RANGE ],
-  [ CONTEXT_QUOTE, '!', REF_RANGE, '.:.', REF_RANGE ],
+  [ CONTEXT_QUOTE, '!', REF_CELL, ':', REF_CELL ],
+  [ CONTEXT_QUOTE, '!', REF_CELL, '.:', REF_CELL ],
+  [ CONTEXT_QUOTE, '!', REF_CELL, ':.', REF_CELL ],
+  [ CONTEXT_QUOTE, '!', REF_CELL, '.:.', REF_CELL ],
+  [ CONTEXT_QUOTE, '!', REF_CELL ],
   [ CONTEXT_QUOTE, '!', REF_RANGE ],
   [ CONTEXT_QUOTE, '!', REF_BEAM ],
   [ CONTEXT_QUOTE, '!', REF_TERNARY ],
@@ -62,7 +64,14 @@ const matcher = (tokens: Token[], currNode, anchorIndex, index = 0) => {
   while (i <= max) {
     const token = tokens[anchorIndex - i];
     if (token) {
-      const key = (token.type === OPERATOR) ? token.value : token.type;
+      const value = token.value;
+      let key = (token.type === OPERATOR) ? value : token.type;
+      // we need to prevent merging ["A1:B2" ":" "C3"] as a range is only
+      // allowed to contain a single ":" operator even if "A1:B2:C3" is
+      // valid Excel syntax
+      if (key === REF_RANGE && value.length > 3 && !value.includes(':')) {
+        key = REF_CELL;
+      }
       if (key in node) {
         node = node[key];
         i += 1;

--- a/lib/tokenize.spec.ts
+++ b/lib/tokenize.spec.ts
@@ -1062,6 +1062,13 @@ describe('lexer', () => {
         { type: FX_PREFIX, value: '=' },
         { type: REF_RANGE, value: 'A1:C1' }
       ]);
+
+      isTokens('=A1:C1:D1', [
+        { type: FX_PREFIX, value: '=' },
+        { type: REF_RANGE, value: 'A1:C1' },
+        { type: OPERATOR, value: ':' },
+        { type: REF_RANGE, value: 'D1' }
+      ]);
     });
 
     test('spill range syntax', () => {


### PR DESCRIPTION
There is an issue in mergeRefTokens which is that chained ranges like `A1:C1:D1` are merged into a single range token. This should not be happening. Rather these should be two ranges and an operation: `A1:C1` `:` `D1`.

This fixes that with a simple fix, but the long term solution will be to tokenize single cell refs as their own token type. I'm not ready to do that just yet, however, because it requires a major version bump.