### PR TITLE
Quote prefixes starting with a digit in stringifyA1Ref

### DIFF
--- a/lib/stringifyA1Ref.spec.ts
+++ b/lib/stringifyA1Ref.spec.ts
@@ -14,6 +14,12 @@ describe('stringifyA1Ref', () => {
     expect(stringifyA1Ref({ context: [ 'My File.xlsx' ], range: rangeA1 })).toBe("'My File.xlsx'!A1");
   });
 
+  test('digit-leading sheet names are quoted', () => {
+    expect(stringifyA1Ref({ context: [ '1040' ], range: rangeA1 })).toBe("'1040'!A1");
+    expect(stringifyA1Ref({ context: [ '1', '1040' ], range: rangeA1 })).toBe("'[1]1040'!A1");
+    expect(stringifyA1Ref({ context: [ '2024Budget' ], range: rangeA1 })).toBe("'2024Budget'!A1");
+  });
+
   test('named ranges', () => {
     expect(stringifyA1Ref({ name: 'foo' })).toBe('foo');
     expect(stringifyA1Ref({ context: [ 'Sheet1' ], name: 'foo' })).toBe('Sheet1!foo');

--- a/lib/stringifyA1Ref.spec.ts
+++ b/lib/stringifyA1Ref.spec.ts
@@ -20,6 +20,12 @@ describe('stringifyA1Ref', () => {
     expect(stringifyA1Ref({ context: [ '2024Budget' ], range: rangeA1 })).toBe("'2024Budget'!A1");
   });
 
+  test('digit-leading prefixes are quoted for named references', () => {
+    expect(stringifyA1Ref({ context: [ '1040' ], name: 'foo' })).toBe("'1040'!foo");
+    expect(stringifyA1Ref({ context: [ '2024Budget' ], name: 'foo' })).toBe("'2024Budget'!foo");
+    expect(stringifyA1Ref({ context: [ '1', '1040' ], name: 'foo' })).toBe("'[1]1040'!foo");
+  });
+
   test('named ranges', () => {
     expect(stringifyA1Ref({ name: 'foo' })).toBe('foo');
     expect(stringifyA1Ref({ context: [ 'Sheet1' ], name: 'foo' })).toBe('Sheet1!foo');
@@ -84,5 +90,14 @@ describe('stringifyA1Ref in XLSX mode', () => {
     expect(stringifyA1RefXlsx({ workbookName: 'Ab12', range: rangeA1 })).toBe("'[Ab12]'!A1");
     expect(stringifyA1RefXlsx({ workbookName: 'Sch1', range: rangeA1 })).toBe("'[Sch1]'!A1");
     expect(stringifyA1RefXlsx({ workbookName: 'Foo12345', range: rangeA1 })).toBe("'[Foo12345]'!A1");
+  });
+
+  test('digit-leading sheet and workbook names are quoted', () => {
+    expect(stringifyA1RefXlsx({ sheetName: '1040', range: rangeA1 })).toBe("'1040'!A1");
+    expect(stringifyA1RefXlsx({ sheetName: '2024Budget', range: rangeA1 })).toBe("'2024Budget'!A1");
+    expect(stringifyA1RefXlsx({ workbookName: '1040.xlsx', range: rangeA1 })).toBe("'[1040.xlsx]'!A1");
+    expect(stringifyA1RefXlsx({ workbookName: '1040.xlsx', sheetName: 'Sheet1', range: rangeA1 })).toBe("'[1040.xlsx]Sheet1'!A1");
+    expect(stringifyA1RefXlsx({ workbookName: '1040.xlsx', name: 'foo' })).toBe("'[1040.xlsx]'!foo");
+    expect(stringifyA1RefXlsx({ sheetName: '1040', name: 'foo' })).toBe("'1040'!foo");
   });
 });

--- a/lib/stringifyPrefix.ts
+++ b/lib/stringifyPrefix.ts
@@ -24,6 +24,11 @@ export function needQuotes (scope: string, yesItDoes = 0): number {
     if (reIsRangelike.test(scope)) {
       return 1;
     }
+    // Sheet names starting with a digit must be quoted in Excel to
+    // avoid ambiguity with numeric literals.
+    if (/^\d/.test(scope)) {
+      return 1;
+    }
   }
   return 0;
 }

--- a/lib/stringifyPrefix.ts
+++ b/lib/stringifyPrefix.ts
@@ -24,7 +24,7 @@ export function needQuotes (scope: string, yesItDoes = 0): number {
     if (reIsRangelike.test(scope)) {
       return 1;
     }
-    // Sheet names starting with a digit must be quoted in Excel to
+    // Sheet/workbook names starting with a digit must be quoted in Excel to
     // avoid ambiguity with numeric literals.
     if (/^\d/.test(scope)) {
       return 1;


### PR DESCRIPTION
What
---

Fix stringification of a reference with a sheet name or workbook name starting with a digit, to quote the prefix.

Why
---

To match Excel behavior. Excel does parse such a reference without complaint, when entered in the formula bar, but it normalizes it, adding quotes, on display and in the saved file.

Examples:

-`1040!A1` is normalized to `'1040'!A1`

- `[1]1040!A1` is normalized to `'[1]1040'!A1`

- `1040.xlsx!NameOfFoo` is shown as `'1040.xlsx'!NameOfFoo` in the formula bar (the formula saved in the file is `[2]!NameOfFoo`, the workbook name is not there so no need for quoting)

How
---

The `needQuotes` function checked for banned characters and range-like patterns but not digit-leading names. Add `/^\d/` check.