### PR TITLE
Serialize the #This Row section specifier in title case

### DIFF
--- a/lib/stringifyStructRef.spec.ts
+++ b/lib/stringifyStructRef.spec.ts
@@ -113,12 +113,18 @@ describe('longform serialize (in xlsx mode)', () => {
       table: 'Table2',
       columns: [ 'col1' ],
       sections: [ 'this row' ]
-    }, { thisRow: true })).toBe('Table2[[#This row],[col1]]');
+    }, { thisRow: true })).toBe('Table2[[#This Row],[col1]]');
 
     expect(stringifyStructRef({
       table: 'Table2',
       columns: [ 'col1' ],
       sections: [ 'this row' ]
-    }, { thisRow: true })).toBe('Table2[[#This row],[col1]]');
+    }, { thisRow: true })).toBe('Table2[[#This Row],[col1]]');
+
+    // Keyword-only this-row (no column) also title-cases both words.
+    expect(stringifyStructRef({
+      table: 'Table2',
+      sections: [ 'this row' ]
+    }, { thisRow: true })).toBe('Table2[#This Row]');
   });
 });

--- a/lib/stringifyStructRef.ts
+++ b/lib/stringifyStructRef.ts
@@ -9,8 +9,10 @@ function needsBraces (str: string): boolean {
   return /[^a-zA-Z0-9\u00a1-\uffff]/.test(str);
 }
 
-function toSentenceCase (str: string): string {
-  return str[0].toUpperCase() + str.slice(1).toLowerCase();
+function toTitleCase (str: string): string {
+  // Section specifiers are title-cased per word, so the two-word `this row`
+  // serializes as `This Row` (Excel's canonical form), not `This row`.
+  return str.toLowerCase().replace(/\b\w/g, c => c.toUpperCase());
 }
 
 export function stringifySRef (refObject: ReferenceStruct, thisRow = false) {
@@ -22,7 +24,7 @@ export function stringifySRef (refObject: ReferenceStruct, thisRow = false) {
   const numSections = refObject.sections?.length ?? 0;
   // single section
   if (numSections === 1 && !numColumns) {
-    s += `[#${toSentenceCase(refObject.sections[0])}]`;
+    s += `[#${toTitleCase(refObject.sections[0])}]`;
   }
   // single column
   else if (!numSections && numColumns === 1) {
@@ -37,7 +39,7 @@ export function stringifySRef (refObject: ReferenceStruct, thisRow = false) {
     }
     else if (numSections) {
       s += refObject.sections
-        .map(d => `[#${toSentenceCase(d)}]`)
+        .map(d => `[#${toTitleCase(d)}]`)
         .join(',');
       if (numColumns) {
         s += ',';


### PR DESCRIPTION
What
---

`stringifyStructRef` serializes the `#This Row` section specifier as `#This row`.

Fix it to emit `#This Row` (both words capitalized), matching Excel's canonical form.

Why
---

Excel always writes `[#This Row]` in stored formulas, so the lower-cased `row` is off-canonical.

Excel does tolerate the different case on load (the keyword is matched case-insensitively) and normalizes it back to `#This Row` on save. So this is low-severity, just a matter of matching the canonical form, not of valid vs invalid.

How
---

Replace the sentence-case helper with a per-word title-case, so each word of a section specifier is capitalized. The tokenizer and parser already preserve/accept `#This Row`; only the object-to-string path was off.