### PR TITLE
fix: unquoted name with non-first high character

### DIFF
--- a/lib/lexers/lexNameFuncCntx.ts
+++ b/lib/lexers/lexNameFuncCntx.ts
@@ -78,7 +78,7 @@ export function lexNameFuncCntx (
   let c: number;
   do {
     c = str.charCodeAt(pos);
-    const a = s > 180 ? OK_HIGHCHAR : ALLOWED[c - OFFS] ?? 0;
+    const a = c > 180 ? OK_HIGHCHAR : ALLOWED[c - OFFS] ?? 0;
     if (a & OK_N) {
       // name: [a-zA-Z_0-9.\\?\u00a1-\uffff]
       // func: [a-zA-Z_0-9.]

--- a/lib/tokenize.spec.ts
+++ b/lib/tokenize.spec.ts
@@ -1149,6 +1149,27 @@ describe('lexer', () => {
         { type: FX_PREFIX, value: '=' },
         { type: REF_RANGE, value: 'Sheet1!A1:B2' }
       ]);
+
+      isTokens('=æði!A1', [
+        { type: FX_PREFIX, value: '=' },
+        { type: CONTEXT, value: 'æði' },
+        { type: OPERATOR, value: '!' },
+        { type: REF_RANGE, value: 'A1' }
+      ], { mergeRefs: false });
+      isTokens('=æði!A1', [
+        { type: FX_PREFIX, value: '=' },
+        { type: REF_RANGE, value: 'æði!A1' }
+      ]);
+      isTokens('=fræði!A1', [
+        { type: FX_PREFIX, value: '=' },
+        { type: CONTEXT, value: 'fræði' },
+        { type: OPERATOR, value: '!' },
+        { type: REF_RANGE, value: 'A1' }
+      ], { mergeRefs: false });
+      isTokens('=fræði!A1', [
+        { type: FX_PREFIX, value: '=' },
+        { type: REF_RANGE, value: 'fræði!A1' }
+      ]);
     });
 
     test('quoted sheet names', () => {
@@ -1203,10 +1224,30 @@ describe('lexer', () => {
         { type: FX_PREFIX, value: '=' },
         { type: REF_RANGE, value: '[filename]Sheetname!A1' }
       ]);
+      isTokens('=[æði]æði!A1', [
+        { type: FX_PREFIX, value: '=' },
+        { type: REF_RANGE, value: '[æði]æði!A1' }
+      ]);
+      isTokens('=[fræði]fræði!A1', [
+        { type: FX_PREFIX, value: '=' },
+        { type: REF_RANGE, value: '[fræði]fræði!A1' }
+      ]);
 
       isTokens('=[filename]Sheetname!A1', [
         { type: FX_PREFIX, value: '=' },
         { type: CONTEXT, value: '[filename]Sheetname' },
+        { type: OPERATOR, value: '!' },
+        { type: REF_RANGE, value: 'A1' }
+      ], { mergeRefs: false });
+      isTokens('=[æði]æði!A1', [
+        { type: FX_PREFIX, value: '=' },
+        { type: CONTEXT, value: '[æði]æði' },
+        { type: OPERATOR, value: '!' },
+        { type: REF_RANGE, value: 'A1' }
+      ], { mergeRefs: false });
+      isTokens('=[fræði]fræði!A1', [
+        { type: FX_PREFIX, value: '=' },
+        { type: CONTEXT, value: '[fræði]fræði' },
         { type: OPERATOR, value: '!' },
         { type: REF_RANGE, value: 'A1' }
       ], { mergeRefs: false });
@@ -1642,6 +1683,10 @@ describe('lexer', () => {
       isTokens('=æði', [
         { type: FX_PREFIX, value: '=' },
         { type: REF_NAMED, value: 'æði' }
+      ]);
+      isTokens('=fræði', [
+        { type: FX_PREFIX, value: '=' },
+        { type: REF_NAMED, value: 'fræði' }
       ]);
       isTokens('=らーめん', [
         { type: FX_PREFIX, value: '=' },


### PR DESCRIPTION
Fix bug: `fræði!A1` tokenizes as `fr` + `æði!A1` instead of one reference. Likewise `fræði` (as a name reference) tokenizes as `fr` + `æði`.

Cause: in `lexNameFuncCntx` the loop checks the token's _first_ character `s` against the high-char range (`s > 180`) but indexes `ALLOWED` with the _current_ character `c`.

Names that _start_ with a high character (`æði`) are unaffected, because `s > 180` is true for them. That is why existing tests did not catch this.

For a name that starts with an ASCII character, `s > 180` is false, so a later high character (e.g. æ, code 230) indexes `ALLOWED` out of bounds, resulting in `undefined`, which is falsy, so the name splits at that character.

Fix: correct the loop to check the current character `c`, not the initial character `s`, against the high-char range.